### PR TITLE
Fix for tinymce options

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -122,17 +122,14 @@ Fliplet().then(function() {
 
   $textarea.tinymce({
     plugins: [
-      'lists advlist image charmap hr code',
-      'searchreplace wordcount insertdatetime table textcolor colorpicker'
-    ],
-    toolbar: [
-      'formatselect |',
-      'bold italic underline strikethrough |',
-      'forecolor backcolor |',
-      'alignleft aligncenter alignright alignjustify | bullist numlist outdent indent |',
-      'blockquote subscript superscript | table insertdatetime charmap hr |',
-      'removeformat | code'
+      'advlist autolink lists link directionality',
+      'autoresize fullscreen code'
     ].join(' '),
+    toolbar: [
+      'bold italic underline',
+      'alignleft aligncenter alignright alignjustify | bullist numlist outdent indent',
+      'ltr rtl | link | removeformat code fullscreen'
+    ].join(' | '),
     menubar: false,
     statusbar: false,
     min_height: 300,


### PR DESCRIPTION
Tinymce options like link and code were missing, bring this in line with the form builders confirmation tinymce setup

Ticket: [PS-1114](https://weboo.atlassian.net/browse/PS-1114)

[PS-1114]: https://weboo.atlassian.net/browse/PS-1114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ